### PR TITLE
Use `x-dead-letter-routing-key` argument

### DIFF
--- a/lib/sneakers_handlers/dead_letter.rb
+++ b/lib/sneakers_handlers/dead_letter.rb
@@ -9,13 +9,15 @@ module SneakersHandlers
     private
 
     def create_dead_letter_exchange!(channel, queue, options)
-      dlx = channel.exchange(options[:queue_options][:arguments].fetch("x-dead-letter-exchange"), {
+      arguments = options[:queue_options][:arguments]
+
+      dlx = channel.exchange(arguments.fetch("x-dead-letter-exchange"), {
         type: options[:exchange_options][:type],
         durable: options[:exchange_options][:durable],
       })
 
       dlx_queue = channel.queue("#{queue.name}.dlx", durable: options[:queue_options][:durable])
-      dlx_queue.bind(dlx, routing_key: options[:routing_key])
+      dlx_queue.bind(dlx, routing_key: arguments.fetch("x-dead-letter-routing-key"))
     end
   end
 end

--- a/test/sneaker_handlers/dead_letter_test.rb
+++ b/test/sneaker_handlers/dead_letter_test.rb
@@ -21,6 +21,7 @@ class SneakersHandlers::DeadLetterTest < Minitest::Test
         durable: true,
         arguments: {
           "x-dead-letter-exchange" => "test.dlx",
+          "x-dead-letter-routing-key" => "dlx-routing-key"
         }
       }
     }
@@ -36,7 +37,7 @@ class SneakersHandlers::DeadLetterTest < Minitest::Test
       durable: true
     }]
 
-    dlx_queue.expect(:bind, nil,[dlx_exchange, routing_key: "pistachio.test"])
+    dlx_queue.expect(:bind, nil,[dlx_exchange, routing_key: "dlx-routing-key"])
 
     SneakersHandlers::DeadLetter.new(channel, queue, options)
   end


### PR DESCRIPTION
Instead of binding the dlx queue to the same routing key as the working
queue, we bind it to the value of the argument
`x-dead-letter-routing-key` to avoid sending the rejected message to
multiple queues.

Example:

1) Queues `a` and `b` are bound to routing key `x`, in the same exchange;
2) A message is received and consumed successfully by queue `a`, but queue
`b` rejects it;
3) The handler would publish the message to the dead-letter exchange using
the routing key `x`, causing it to end up in both dead-letter queues (`a.dlx` and `b.dlx`).

With this change, as long as these two queues where declared with a
different `x-dead-letter-routing-key`, the message would end up just in
the queue that originally rejected it.

We would probably use the queue name as the `x-dead-letter-routing-key`
value to guarantee uniqueness.