### PR TITLE
[WIP] Spike delayed retry

### DIFF
--- a/lib/sneakers_handlers/delayed_retry_handler.rb
+++ b/lib/sneakers_handlers/delayed_retry_handler.rb
@@ -1,0 +1,102 @@
+module SneakersHandlers
+  class DelayedRetryHandler
+    def initialize(channel, queue, options)
+      @queue = queue
+
+      @channel = channel
+      @options = options
+
+      @retry_exchange = exchange("#{options[:exchange]}.retry")
+      @retry_queue = @channel.queue(retry_name,
+        durable: durable_queues?,
+        arguments: {
+          "x-dead-letter-exchange": options[:exchange],
+          "x-message-ttl": options[:retry_delay] || 5_000,
+        }
+      )
+
+      @retry_queue.bind(@retry_exchange, routing_key: options[:routing_key])
+
+      @error_exchange = exchange("#{options[:exchange]}.error")
+      @error_queue = @channel.queue(error_name, durable: durable_queues?)
+      @error_queue.bind(@error_exchange, routing_key: options[:routing_key])
+
+      @max_retries = @options[:retry_max_times] || 5
+    end
+
+    def acknowledge(delivery_info, _, _)
+      @channel.acknowledge(delivery_info.delivery_tag, false)
+    end
+
+    def reject(delivery_info, properties, message)
+      retry_message(delivery_info, properties, message, :reject)
+    end
+
+    def error(delivery_info, properties, message, err)
+      retry_message(delivery_info, properties, message, err)
+    end
+
+    def timeout(delivery_info, properties, message)
+      retry_message(delivery_info, properties, message, :timeout)
+    end
+
+    def noop(delivery_info, properties, message); end
+
+    private
+
+    def retry_message(delivery_info, properties, message, reason)
+      attempt_number = death_count(properties[:headers])
+
+      if attempt_number < @max_retries
+        log("msg=retrying, count=#{attempt_number}, properties=#{properties}")
+
+        @channel.reject(delivery_info.delivery_tag, false)
+      else
+        log("msg=erroring, count=#{attempt_number}, properties=#{properties}")
+
+        @error_exchange.publish(message, routing_key: delivery_info[:routing_key])
+        acknowledge(delivery_info, properties, message)
+      end
+    end
+
+    def death_count(headers)
+      return 0 if headers.nil? || headers["x-death"].nil?
+
+      headers["x-death"].inject(0) do |sum, x_death|
+        sum + x_death["count"] if x_death["queue"] == primary_name
+      end
+    end
+
+    def primary_name
+      @queue.name
+    end
+
+    def retry_name
+      "#{primary_name}.retry"
+    end
+
+    def error_name
+      "#{primary_name}.error"
+    end
+
+    def exchange(name)
+      log("creating exchange=#{name}")
+
+      @channel.exchange(name, type: "topic", durable: durable_exchanges?)
+    end
+
+    def log(message)
+      Sneakers.logger.debug do
+        "DelayedRetryHandler handler [queue=#{@primary_queue_name}] #{message}"
+      end
+    end
+
+    def durable_exchanges?
+      @options[:exchange_options][:durable]
+    end
+
+    def durable_queues?
+      @options[:queue_options][:durable]
+    end
+  end
+end

--- a/test/sneaker_handlers/dead_letter_handler_test.rb
+++ b/test/sneaker_handlers/dead_letter_handler_test.rb
@@ -3,10 +3,15 @@ require "support/dead_letter_worker_failure"
 require "support/dead_letter_worker_success"
 
 class SneakersHandlers::DeadLetterHandlerTest < Minitest::Test
+  def setup
+    cleanup!
+  end
+
+  def teardown
+    cleanup!
+  end
 
   def test_dead_letter_messages
-    delete_test_queues!
-
     exchange = channel.topic("sneakers_handlers", durable: false)
 
     DeadLetterWorkerFailure.new.run
@@ -34,7 +39,10 @@ class SneakersHandlers::DeadLetterHandlerTest < Minitest::Test
                  end
   end
 
-  def delete_test_queues!
+  def cleanup!
+    channel.exchange_delete("sneakers_handlers")
+    channel.exchange_delete("sneakers_handlers.dlx")
+
     [DeadLetterWorkerFailure, DeadLetterWorkerSuccess].each do |worker|
       channel.queue_delete(worker.queue_name)
       channel.queue_delete(worker.queue_name + ".dlx")

--- a/test/sneaker_handlers/retry_handler_test.rb
+++ b/test/sneaker_handlers/retry_handler_test.rb
@@ -3,9 +3,15 @@ require "support/retry_worker_failure"
 require "support/retry_worker_success"
 
 class SneakersHandlers::RetryHandlerTest < Minitest::Test
-  def test_max_retry_goes_to_dlx
-    delete_test_queues!
+  def setup
+    cleanup!
+  end
 
+  def teardown
+    cleanup!
+  end
+
+  def test_max_retry_goes_to_dlx
     exchange = channel.topic("sneakers_handlers", durable: false)
 
     RetryWorkerFailure.new.run
@@ -33,7 +39,10 @@ class SneakersHandlers::RetryHandlerTest < Minitest::Test
                  end
   end
 
-  def delete_test_queues!
+  def cleanup!
+    channel.exchange_delete("sneakers_handlers")
+    channel.exchange_delete("sneakers_handlers.dlx")
+
     [RetryWorkerFailure, RetryWorkerSuccess].each do |worker|
       channel.queue_delete(worker.queue_name)
       channel.queue_delete(worker.queue_name + ".dlx")


### PR DESCRIPTION
Spike out a delayed retry. 

Leverages `x-death` headers from dead letter exchanges to count retries. Does not require a special dead letter routing key.

This uses three exchanges (these can be shared by queues). And it requires two queues per primary queue (a retry and an error). The retry is a holding place that has it's message TTL'd and dead letters bak to the primary queue. When the max retries have been done, it publishes to the error exchange (with the routing key of the original message).

Would end up looking like this for us:

### Exchanges
`domain_events`
`domain_events.retry`
`domain_events.error`

### Queues
`cp-dashboard.user_syncer`
`cp-dashboard.user_syncer.retry`
`cp-dashboard.user_syncer.error`

So you can see we share exchanges, but each queue gets it's own retry and error queue.

#### Flow
![delayed retry flow](https://cloud.githubusercontent.com/assets/401301/14652093/ca163bf6-0640-11e6-85eb-fcbd57529c19.png)

#### Dead letter flow
![dead_letters_-_google_drawings](https://cloud.githubusercontent.com/assets/401301/14652058/a2f1f59c-0640-11e6-9189-5fb6352fd861.png)

### Exponential backoff
We can accomplish this with a similar setup but more queues