### PR TITLE
Fix handler interface and use real exponential backoff

### DIFF
--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -1,3 +1,26 @@
+# Using this handler, failed messages will be retried with an exponential
+# backoff delay, for a certain number of times, until they are dead-lettered.
+#
+# To use it you need to defined this handler in your worker:
+#
+# from_queue "my-app.queue_name",
+#   exchange: "my_exchange_name",
+#   routing_key: "my_routing_key",
+#   handler: SneakersHandlers::ExponentialBackoffHandler,
+#   arguments: { "x-dead-letter-exchange" => "my_exchange_name.dlx",
+#                "x-dead-letter-routing-key" => "my-app.queue_name" }}
+#
+# By default it will retry 25 times before dead-lettering a message, but you can
+# also customize that with the `max_retries` option:
+#
+# from_queue "my-app.queue_name",
+#   exchange: "my_exchange_name",
+#   routing_key: "my_routing_key",
+#   max_retries: 10,
+#   handler: SneakersHandlers::ExponentialBackoffHandler,
+#   arguments: { "x-dead-letter-exchange" => "my_exchange_name.dlx",
+#                "x-dead-letter-routing-key" => "my-app.queue_name" }}
+
 module SneakersHandlers
   class ExponentialBackoffHandler
     attr_reader :queue, :channel, :options, :max_retries
@@ -12,9 +35,7 @@ module SneakersHandlers
 
       create_error_exchange!
 
-      Array(@options[:routing_key]).each do |key|
-        queue.bind(primary_exchange, routing_key: queue.name + "." + key + ".*")
-      end
+      queue.bind(primary_exchange, routing_key: queue.name)
     end
 
     def acknowledge(delivery_info, _, _)
@@ -41,28 +62,22 @@ module SneakersHandlers
     def retry_message(delivery_info, properties, message, reason)
       attempt_number = death_count(properties[:headers])
 
-      routing_key_segments = (queue.name + "." + delivery_info[:routing_key].gsub(queue.name + ".", "")).split(".")
-      routing_key_segments.pop if Integer(routing_key_segments.last) rescue nil
-
       if attempt_number < max_retries
         delay = seconds_to_delay(attempt_number)
 
         log("msg=retrying, delay=#{delay}, count=#{attempt_number}, properties=#{properties}, reason=#{reason}")
 
-        routing_key_segments << delay
-        routing_key = routing_key_segments.join(".")
+        routing_key = "#{queue.name}.#{delay}"
 
         retry_queue = create_retry_queue!(delay)
-        retry_queue.bind(retry_exchange, routing_key: routing_key)
+        retry_queue.bind(primary_exchange, routing_key: routing_key)
 
-        retry_exchange.publish(message, routing_key: routing_key, headers: properties[:headers])
+        primary_exchange.publish(message, routing_key: routing_key, headers: properties[:headers])
+        acknowledge(delivery_info, properties, message)
       else
         log("msg=erroring, count=#{attempt_number}, properties=#{properties}")
-
         channel.reject(delivery_info.delivery_tag)
       end
-
-      acknowledge(delivery_info, properties, message)
     end
 
     def death_count(headers)
@@ -74,27 +89,15 @@ module SneakersHandlers
     end
 
     def log(message)
-      Sneakers.logger.debug do
-        "[#{self.class}] [queue=#{@primary_queue_name}] #{message}"
+      Sneakers.logger.info do
+        "[#{self.class}] #{message}"
       end
-    end
-
-    def durable_exchanges?
-      options[:exchange_options][:durable]
-    end
-
-    def durable_queues?
-      options[:queue_options][:durable]
     end
 
     def create_exchange(name)
       log("creating exchange=#{name}")
 
-      @channel.exchange(name, type: "topic", durable: durable_exchanges?)
-    end
-
-    def retry_exchange
-      @retry_exchange ||= create_exchange("#{options[:exchange]}.retry")
+      channel.exchange(name, type: "topic", durable: options[:exchange_options][:durable])
     end
 
     def primary_exchange
@@ -102,29 +105,42 @@ module SneakersHandlers
     end
 
     def create_error_exchange!
-      @error_exchange ||= create_exchange("#{options[:exchange]}.error").tap do |exchange|
-        queue = @channel.queue("#{@queue.name}.error", durable: durable_queues?)
+      arguments = options[:queue_options][:arguments]
 
-        Array(@options[:routing_key]).each do |key|
-          queue.bind(exchange, routing_key: @queue.name + "." + key)
-          queue.bind(exchange, routing_key: @queue.name + "." + key + ".*")
-        end
+      dlx_exchange_name = arguments.fetch("x-dead-letter-exchange")
+      dlx_routing_key = arguments.fetch("x-dead-letter-routing-key")
+
+      @error_exchange ||= create_exchange(dlx_exchange_name).tap do |exchange|
+        queue = channel.queue("#{@queue.name}.error", durable: options[:queue_options][:durable])
+        queue.bind(exchange, routing_key: dlx_routing_key)
       end
     end
 
     def create_retry_queue!(delay)
-      @channel.queue("#{queue.name}.retry.#{delay}",
-       durable: durable_queues?,
-       arguments: {
-         :"x-dead-letter-exchange" => options[:exchange],
-         :"x-message-ttl" => delay * 1_000,
-         :"x-expires" => delay * 1_000 * 2
-       }
-      )
+      clear_queues_cache
+      channel.queue( "#{queue.name}.retry.#{delay}",
+         durable: options[:queue_options][:durable],
+         arguments: {
+           :"x-dead-letter-exchange" => options[:exchange],
+           :"x-dead-letter-routing-key" => queue.name,
+           :"x-message-ttl" => delay * 1_000,
+           :"x-expires" => delay * 1_000 * 2
+         }
+        )
     end
 
     def seconds_to_delay(count)
       (count + 1) ** 2
+    end
+
+    # When we create a new queue, `Bunny` stores its name in an internal cache.
+    # The problem is that as we are creating ephemeral queues that can expire shortly
+    # after they are created, this cached queue may not exist anymore when we try to
+    # publish a second message to it.
+    # Removing queues from the cache guarantees that `Bunny` will always try
+    # to check if they exist, and when they don't, it will create them for us.
+    def clear_queues_cache
+      channel.queues.clear
     end
   end
 end


### PR DESCRIPTION
We were using the wrong arity for the `reject` method in the `ExponentialBackoffHandler`. When a message is being requeued, `Sneakers` calls it with 4 parameters instead of 3. I changed the tests for this handler to actually test all the possible responses (`reject`, `error`, `timeout` and `requeue`) to make sure it always works.

I also removed the `delays` options and added real exponential backoff, so the only thing the worker can specify is the maximum number of retries, with the `max_retries` options, that uses a default of 25.

cc/ @toreriklinnerud @abepetrillo 