### PR TITLE
Report rejection reason

### DIFF
--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -49,7 +49,7 @@ module SneakersHandlers
     end
 
     def error(delivery_info, properties, message, err)
-      retry_message(delivery_info, properties, message, err)
+      retry_message(delivery_info, properties, message, err.inspect)
     end
 
     def timeout(delivery_info, properties, message)
@@ -74,7 +74,8 @@ module SneakersHandlers
         retry_queue = create_retry_queue!(delay)
         retry_queue.bind(primary_exchange, routing_key: routing_key)
 
-        primary_exchange.publish(message, routing_key: routing_key, headers: properties[:headers])
+        headers = (properties[:headers] || {}).merge(rejection_reason: reason.to_s)
+        primary_exchange.publish(message, routing_key: routing_key, headers: headers)
         acknowledge(delivery_info, properties, message)
       else
         log("msg=erroring, count=#{attempt_number}, properties=#{properties}")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require "sneakers_handlers"
 require "minitest/autorun"
 require "minitest/reporters"
 require "sneakers"
+require 'pry-byebug'
 
 Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
 


### PR DESCRIPTION
When an unhandled exception is raised we have access to it in the `error` method. We can then use this exception to include the error message as a new header in the error message:

![screenshot_2017-01-06_18_49_57](https://cloud.githubusercontent.com/assets/183363/21732619/7d027d3c-d441-11e6-8959-222e189b3e90.png)
