### PR TITLE
Record "rejection_reason" for the RetryHandler

### DIFF
--- a/test/sneaker_handlers/retry_handler_test.rb
+++ b/test/sneaker_handlers/retry_handler_test.rb
@@ -13,6 +13,7 @@ class SneakersHandlers::RetryHandlerTest < Minitest::Test
     exchange = channel.topic("sneakers_handlers", durable: false)
 
     RetryWorkerFailure.new.run
+    RetryWorkerError.new.run
     RetryWorkerSuccess.new.run
 
     2.times do
@@ -23,8 +24,17 @@ class SneakersHandlers::RetryHandlerTest < Minitest::Test
 
     success_dead_letter_queue = channel.queue(RetryWorkerSuccess.queue_name + ".error")
     failure_dead_letter_queue = channel.queue(RetryWorkerFailure.queue_name + ".error")
+    error_dead_letter_queue = channel.queue(RetryWorkerError.queue_name + ".error")
+
 
     assert_equal 2, failure_dead_letter_queue.message_count
+    _delivery_info, failure_properties, _message = channel.basic_get(RetryWorkerFailure.queue_name + ".error")
+    assert_equal "reject", failure_properties.dig(:headers, "rejection_reason")
+
+    assert_equal 2, error_dead_letter_queue.message_count
+    _delivery_info, error_properties, _message = channel.basic_get(RetryWorkerError.queue_name + ".error")
+    assert_equal "#<RuntimeError: exceptions are also handled>", error_properties.dig(:headers, "rejection_reason")
+
     assert_equal 0, success_dead_letter_queue.message_count
   end
 
@@ -60,7 +70,7 @@ class SneakersHandlers::RetryHandlerTest < Minitest::Test
     channel.exchange_delete("sneakers_handlers")
     channel.exchange_delete("sneakers_handlers.dlx")
 
-    [RetryWorkerFailure, RetryWorkerSuccess].each do |worker|
+    [RetryWorkerFailure, RetryWorkerError, RetryWorkerSuccess].each do |worker|
       channel.queue_delete(worker.queue_name)
       channel.queue_delete(worker.queue_name + ".error")
     end
@@ -82,6 +92,24 @@ class RetryWorkerSuccess
 
   def work(payload)
     return ack!
+  end
+end
+
+class RetryWorkerError
+  include Sneakers::Worker
+
+  from_queue "sneaker_handlers.retry_error_test",
+  ack: true,
+  durable: false,
+  exchange: "sneakers_handlers",
+  exchange_type: :topic,
+  routing_key: "sneakers_handlers.retry_test",
+  handler: SneakersHandlers::RetryHandler,
+  arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
+               "x-dead-letter-routing-key" => "sneaker_handlers.retry_error_test" }
+
+  def work(payload)
+    raise "exceptions are also handled"
   end
 end
 


### PR DESCRIPTION
This is something that we already do for the `ExponentialBackoffHandler`, so I'm just replicating the same behaviour for the `RetryHandler`.

When a message fails because of an unhandled exception it's useful to see this exception in the queue headers, so it's a lot easier to debug what caused the failure.

<img width="710" alt="rabbitmq_management" src="https://user-images.githubusercontent.com/183363/31762423-70282e94-b4bb-11e7-9a73-e5725c74f801.png">
