### PR TITLE
Add tests for the rejection reason in the `ExponentialBackoffHandler`

### DIFF
--- a/test/sneaker_handlers/exponential_backoff_handler_test.rb
+++ b/test/sneaker_handlers/exponential_backoff_handler_test.rb
@@ -76,6 +76,14 @@ class SneakersHandlers::ExponentialBackoffHandlerTest < Minitest::Test
     sleep 4
 
     assert_equal 10, error_queue.message_count
+
+    rejection_reasons = error_queue.message_count.times.map do
+      _delivery_info, properties, _message = channel.basic_get(error_queue.name, manual_ack: false)
+      properties.dig(:headers, "rejection_reason")
+    end.uniq
+
+    expected_reasons = ["timeout", "nil", "reject", "#<RuntimeError: Unhandled exceptions should be retried>"]
+    assert_equal expected_reasons.sort, rejection_reasons.sort
   end
 
   def test_works_when_shoveling_messages


### PR DESCRIPTION
When a message fails and is sent to the `.error` queue, we add a `rejection_reason` property in the message's header, so it's a lot easier to identify what caused the issue. This usually includes the exception/message that triggered the failure.

This PR is just testing this behaviour is working as we expect.