### PR TITLE
[Bugfix] Record reason for latest failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ class RetryWorker
 
   from_queue "sneakers_handlers.my_queue",
       ack: true,
-      exchange: "sneaker_handlers",
+      exchange: "sneakers_handlers",
       exchange_type: :topic,
       routing_key: "sneakers_handlers.retry_test",
 +     handler: SneakersHandlers::RetryHandler,
@@ -86,7 +86,7 @@ class ExponentialBackoffWorker
 
   from_queue "sneakers_handlers.my_queue",
       ack: true,
-      exchange: "sneaker_handlers",
+      exchange: "sneakers_handlers",
       exchange_type: :topic,
       routing_key: "sneakers_handlers.backoff_test",
 +     handler: SneakersHandlers::ExponentialBackoffHandler,
@@ -109,7 +109,7 @@ class ExponentialBackoffWorker
 
   from_queue "sneakers_handlers.my_queue",
       ack: true,
-      exchange: "sneaker_handlers",
+      exchange: "sneakers_handlers",
       exchange_type: :topic,
       routing_key: "sneakers_handlers.backoff_test",
       handler: SneakersHandlers::ExponentialBackoffHandler,

--- a/test/sneakers_handlers/dead_letter_handler_test.rb
+++ b/test/sneakers_handlers/dead_letter_handler_test.rb
@@ -70,7 +70,7 @@ end
 class DeadLetterWorkerSuccess
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.dead_letter_success_test",
+  from_queue "sneakers_handlers.dead_letter_success_test",
     ack: true,
     durable: false,
     exchange: "sneakers_handlers",
@@ -78,7 +78,7 @@ class DeadLetterWorkerSuccess
     routing_key: "sneakers_handlers.dead_letter_test",
     handler: SneakersHandlers::DeadLetterHandler,
     arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-                 "x-dead-letter-routing-key" => "sneaker_handlers.dead_letter_success_test" }
+                 "x-dead-letter-routing-key" => "sneakers_handlers.dead_letter_success_test" }
 
   def work(*args)
     ack!
@@ -88,7 +88,7 @@ end
 class DeadLetterWorkerFailure
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.dead_letter_failure_test",
+  from_queue "sneakers_handlers.dead_letter_failure_test",
     ack: true,
     durable: false,
     exchange: "sneakers_handlers",
@@ -96,7 +96,7 @@ class DeadLetterWorkerFailure
     routing_key: "sneakers_handlers.dead_letter_test",
     handler: SneakersHandlers::DeadLetterHandler,
     arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-                 "x-dead-letter-routing-key" => "sneaker_handlers.dead_letter_failure_test" }
+                 "x-dead-letter-routing-key" => "sneakers_handlers.dead_letter_failure_test" }
 
   def work(*args)
     reject!
@@ -106,7 +106,7 @@ end
 class DeadLetterFanoutWorkerSuccess
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.dead_letter_success_test",
+  from_queue "sneakers_handlers.dead_letter_success_test",
     ack: true,
     durable: false,
     exchange: "sneakers_handlers",
@@ -114,7 +114,7 @@ class DeadLetterFanoutWorkerSuccess
     routing_key: "sneakers_handlers.dead_letter_test",
     handler: SneakersHandlers::DeadLetterHandler,
     arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-                 "x-dead-letter-routing-key" => "sneaker_handlers.dead_letter_success_test" }
+                 "x-dead-letter-routing-key" => "sneakers_handlers.dead_letter_success_test" }
 
   def work(*args)
     ack!
@@ -124,7 +124,7 @@ end
 class DeadLetterFanoutWorkerFailure
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.dead_letter_failure_test",
+  from_queue "sneakers_handlers.dead_letter_failure_test",
     ack: true,
     durable: false,
     exchange: "sneakers_handlers",
@@ -132,7 +132,7 @@ class DeadLetterFanoutWorkerFailure
     routing_key: "sneakers_handlers.dead_letter_test",
     handler: SneakersHandlers::DeadLetterHandler,
     arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-                 "x-dead-letter-routing-key" => "sneaker_handlers.dead_letter_failure_test" }
+                 "x-dead-letter-routing-key" => "sneakers_handlers.dead_letter_failure_test" }
 
   def work(*args)
     reject!

--- a/test/sneakers_handlers/retry_handler_test.rb
+++ b/test/sneakers_handlers/retry_handler_test.rb
@@ -80,7 +80,7 @@ end
 class RetryWorkerSuccess
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.retry_success_test",
+  from_queue "sneakers_handlers.retry_success_test",
   ack: true,
   durable: false,
   exchange: "sneakers_handlers",
@@ -88,7 +88,7 @@ class RetryWorkerSuccess
   routing_key: "sneakers_handlers.retry_test",
   handler: SneakersHandlers::RetryHandler,
   arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-               "x-dead-letter-routing-key" => "sneaker_handlers.retry_success_test" }
+               "x-dead-letter-routing-key" => "sneakers_handlers.retry_success_test" }
 
   def work(payload)
     return ack!
@@ -98,7 +98,7 @@ end
 class RetryWorkerError
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.retry_error_test",
+  from_queue "sneakers_handlers.retry_error_test",
   ack: true,
   durable: false,
   exchange: "sneakers_handlers",
@@ -106,7 +106,7 @@ class RetryWorkerError
   routing_key: "sneakers_handlers.retry_test",
   handler: SneakersHandlers::RetryHandler,
   arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-               "x-dead-letter-routing-key" => "sneaker_handlers.retry_error_test" }
+               "x-dead-letter-routing-key" => "sneakers_handlers.retry_error_test" }
 
   def work(payload)
     raise "exceptions are also handled"
@@ -116,7 +116,7 @@ end
 class RetryWorkerFailure
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.retry_failure_test",
+  from_queue "sneakers_handlers.retry_failure_test",
   ack: true,
   durable: false,
   exchange: "sneakers_handlers",
@@ -124,7 +124,7 @@ class RetryWorkerFailure
   routing_key: "sneakers_handlers.retry_test",
   handler: SneakersHandlers::RetryHandler,
   arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-               "x-dead-letter-routing-key" => "sneaker_handlers.retry_failure_test" }
+               "x-dead-letter-routing-key" => "sneakers_handlers.retry_failure_test" }
 
   def work(payload)
     return reject!
@@ -134,7 +134,7 @@ end
 class RetryFanoutWorkerSuccess
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.retry_success_test",
+  from_queue "sneakers_handlers.retry_success_test",
   ack: true,
   durable: false,
   exchange: "sneakers_handlers",
@@ -142,7 +142,7 @@ class RetryFanoutWorkerSuccess
   routing_key: "sneakers_handlers.retry_test",
   handler: SneakersHandlers::RetryHandler,
   arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-               "x-dead-letter-routing-key" => "sneaker_handlers.retry_success_test" }
+               "x-dead-letter-routing-key" => "sneakers_handlers.retry_success_test" }
 
   def work(payload)
     return ack!
@@ -152,7 +152,7 @@ end
 class RetryFanoutWorkerFailure
   include Sneakers::Worker
 
-  from_queue "sneaker_handlers.retry_failure_test",
+  from_queue "sneakers_handlers.retry_failure_test",
   ack: true,
   durable: false,
   exchange: "sneakers_handlers",
@@ -160,7 +160,7 @@ class RetryFanoutWorkerFailure
   routing_key: "sneakers_handlers.retry_test",
   handler: SneakersHandlers::RetryHandler,
   arguments: { "x-dead-letter-exchange" => "sneakers_handlers.dlx",
-               "x-dead-letter-routing-key" => "sneaker_handlers.retry_failure_test" }
+               "x-dead-letter-routing-key" => "sneakers_handlers.retry_failure_test" }
 
   def work(payload)
     return reject!


### PR DESCRIPTION
This is a scenario where we'd report the wrong failure reason:

1) Message is published to queue;
2) Message fails with error `first_error`;
3) We record this failure in the `rejection_reason` header and publish this message to the retry queues, until it reaches the error queue;
4) We can then inspect the message headers (e.g. in the management UI) and see the `rejection_reason` to investigate what happened;
5) After the issue is fixed we shovel the message back to the working queue;
6) This time the message fails with error `second_error`;
7) As this message was just being [rejected](https://github.com/alphasights/sneakers_handlers/blob/2004126174f2d3a4d9afb05dcab0a98fb571c1f0/lib/sneakers_handlers/exponential_backoff_handler.rb#L83), we were not able to update the message headers with the new `rejection_reason`, so if you checked this message you would still see `first_error`.

Now instead of rejecting the original message we are acknowledging it and directly publishing a copy of this message to the error queue with the correct headers.

This PR also fix some typos.