### PR TITLE
Add support for Ruby 3.0 and restrict Ruby 2.x to actual versions

### DIFF
--- a/lib/sneakers_handlers/version.rb
+++ b/lib/sneakers_handlers/version.rb
@@ -1,3 +1,3 @@
 module SneakersHandlers
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 end

--- a/sneakers_handlers.gemspec
+++ b/sneakers_handlers.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "sneakers", "~> 2.0"
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry-byebug", "~> 3.5"


### PR DESCRIPTION
Ruby 3 support. Remove Ruby 2.x support for EOL versions

Specs are passing on Ruby 3.1.2