### PR TITLE
fix: update headers for RabbitMQ 4 compatibility

### DIFF
--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -66,7 +66,9 @@ module SneakersHandlers
 
     def retry_message(delivery_info, properties, message, reason)
       attempt_number = death_count(properties[:headers])
-      headers = (properties[:headers] || {}).merge(rejection_reason: reason.to_s)
+      headers = (properties[:headers] || {})
+          .merge(rejection_reason: reason.to_s)
+          .merge("death-count" => attempt_number + 1)
       headers = remove_delayed_message_header(headers)
 
       if attempt_number < max_retries
@@ -115,11 +117,7 @@ module SneakersHandlers
     end
 
     def death_count(headers)
-      return 0 if headers.nil? || headers["x-death"].nil?
-
-      headers["x-death"].inject(0) do |sum, x_death|
-        sum + x_death["count"] if x_death["queue"] =~ /^#{queue.name}/
-      end
+      headers&.[]("death-count").to_i
     end
 
     def log(message:, level: :info)

--- a/lib/sneakers_handlers/retry_handler.rb
+++ b/lib/sneakers_handlers/retry_handler.rb
@@ -69,7 +69,7 @@ module SneakersHandlers
 
     def retry_message(hdr, props, msg, reason)
       headers = props[:headers] || {}
-      retry_count = headers["x-retry-count"] || 1
+      retry_count = headers["retry_count"] || 1
       if retry_count >= @max_retry
         @channel.reject(hdr.delivery_tag)
       else
@@ -77,7 +77,7 @@ module SneakersHandlers
           "Retrying message: queue=#{@queue.name} retry_count=#{retry_count} reason=#{reason}."
         end
 
-        headers = headers.merge({ "x-retry-count": retry_count + 1, "rejection_reason": reason.to_s })
+        headers = headers.merge({ "retry_count" => retry_count + 1, "rejection_reason" => reason.to_s })
         @channel.default_exchange.publish(msg,
                                           routing_key: @queue.name,
                                           headers: headers)


### PR DESCRIPTION
RabbitMQ now treats all headers starting with x- as internal so they can no longer be set by the client