### PR TITLE
Updating Sneakers to kicks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   specs:
     working_directory: ~/app
     docker:
-      - image: circleci/ruby:2.6.3-node-browsers
+      - image: circleci/ruby:2.7-node-browsers
       - image: alphasights/rabbitmq:3.7
     steps:
       - checkout

--- a/sneakers_handlers.gemspec
+++ b/sneakers_handlers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "sneakers", "~> 2.0"
+  spec.add_dependency "kicks", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/sneakers_handlers.gemspec
+++ b/sneakers_handlers.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "kicks", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry-byebug", "~> 3.5"
   spec.add_development_dependency "minitest-reporters", "~> 1.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency swap on the core RabbitMQ worker stack can break consumers at runtime if `kicks` API differs from `sneakers`; CI-only Ruby bump is lower risk but must match the new `required_ruby_version`.
> 
> **Overview**
> **Replaces the `sneakers` runtime dependency with `kicks` (~> 3.0)** and aligns the gem with **Ruby >= 2.7**, bumping dev **Rake** to ~> 13.0.
> 
> CircleCI’s **specs** job now runs on **`circleci/ruby:2.7-node-browsers`** instead of 2.6.3, matching the new minimum Ruby version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536fad28a560b843c6d4fd709a5dd1e34cf1cac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->